### PR TITLE
Write secure HTTP API spike

### DIFF
--- a/0013-secure-http-api.adoc
+++ b/0013-secure-http-api.adoc
@@ -1,5 +1,4 @@
 = Securing the `cnd` HTTP API
-
 Tobin C. Harding <tobin.harding@coblox.tech>
 :toc:
 :revdate: 2019-08-13

--- a/0013-secure-http-api.adoc
+++ b/0013-secure-http-api.adoc
@@ -52,34 +52,94 @@ The industry standard for encrypting traffic over a network is Transport Layer S
 * Replay protection - not needed, replay attack vector currently non-existent for cnd.
 * Sequence protection - no obvious need.
 
-There is a usability concern that for clients that use a webbrowser e.g. `comit-i` how we sign the certificate will effect the user experience.
-A self signed cert will cause a security warning to be displayed by modern browsers.
-Installing a CA to counter the issue will require root privileges, something that we do not wish to require.
+=== Certificates
+
+TLS requires a certificate (private/public keypair) to be preset on the server i.e., cnd.
+Note, this negatively impacts our quarterly OKR #48 (Make COMIT easily accessible).
+
+There are multiple solutions to getting a certificate onto the machine running cnd, each with different pros/cons.
+
+==== Signed certificate by trusted CA
+
+Use case: running cnd on an internet facing host with a registered domain.
+Purchase a certificate signed by a trusted CA.
+
+.pros
+* This is how it would need to be done if cnd is offered as a service i.e., to mobile clients
+* Industry standard
+
+.cons
+* Resource intensive, money and time.
+* Unnecessary for use cases where cnd is on the same machine as the client
+* Not suitable for development
+
+==== Signed certificate by private CA
+
+Use case: running cnd on same machine as the client.
+Create a private CA and configure the host machine to trust certificates signed by the private CA.
+
+.pros
+* Free
+* Makes using the client with HTTPS seamless
+
+.cons
+* Requires root access to the host machine
+* Complex if done manually, however there is a tool (untested) that claims to simplify this: https://blog.filippo.io/mkcert-valid-https-certificates-for-localhost/
+* Operator of cnd still has to create and sign certificates for use by cnd i.e., increases complexity
+
+=== Self signed certificate
+
+Use case: running cnd on same machine as the client.
+Create a self signed certificate.
+
+.pros
+* Free
+* Within the realm of typical developer knowledge
+
+.cons
+* Adds complexity to the set up of cnd
+* Negatively impacts usability, browser security pop up because of untrusted certificate
 
 == Implementing TLS
+
+There are two aspects to encrypting traffic between cnd to the client.
+1. The HTTP API exposed by cnd needs to be encrypted using TLS.
+2. *Our* client implementation, `comit-i` needs to be served by cnd using TLS.
 
 === cnd
 
 Adding TLS to cnd should be straightforward.
-TLS is supported by Warp (the web server framework we use).
-The only real consideration is the TLS keypair (key and certificate) and selfsigning the certificate.
-We can provide a default keypair so that cnd works out of the box with TLS.
 
-.This can be done in a few ways:
-* Put the keys in the repository - bad, private keys should be private.
-* Write a standalone tool to generate a new key.
-* Add code to cnd to generate a new keypair if one is not found i.e. in the default place or via a config option `--key=/path/to/key`and `--cert=/path/to/cert`.
+There are two parts to this:
+1. Exposing the HTTP API vial TLS (so clients can connect to cnd using TLS)
+2. Serving `comit-i` via TLS (so the browser can use `https://` addresses)
+
+Since both of these are done by calls to Warp they can both be done in the same manner.
+TLS is supported by Warp (the web server framework we use).
+Requires adding a field in the config file and command line options e.g., `--tls-key=/path/to/key` and `--tls-cert=/path/to/cert`.
+Adds an extra initial setup step for the user of cnd to ensure valid certificate is available on the host machine.
 
 === comit-i
 
-Request content for this section to be written by team member who is familiar with `comit-i` and/or React.
+`comit-i` must consume the HTTP API exposed by cnd using TLS
+I was unable to find any information on the internet on how to do this.
 
 == Recommendation
+
+The cnd stuff is straightforward.
 
 .Recommendations are as follows:
 * Implement TLS for cnd using Warp's TLS support.
 ** Enable TLS by default, add option `--no-tls` to disable it.
 ** Look for keypair in well known location, configurable via configuration file and command line options.
+* Leave generation of valid certificate up to the user of cnd but add documentation/hints on how to do this and what options are available (based on information in this spike).
+
+As for `comit-i` my findings were less positive.
+Recommend splitting `comit-i` up into separate parts for the front end and back end and re-writing the back end in Rust.
+Rust has a library `rust-native-tls` which is an abstraction over platform-specific TLS implementations and will facilitate connecting to cnd using TLS.
+
+.Failed research question:
+* Connect to cnd from `comit-i` using TLS via Typescript or Javascript library.
 
 == Reference
 

--- a/0013-secure-http-api.adoc
+++ b/0013-secure-http-api.adoc
@@ -4,8 +4,8 @@ Tobin C. Harding <tobin.harding@coblox.tech>
 :toc:
 :revdate: 2019-08-13
 
-* Authors(s): {authors}
-* Date: {revdate}
+* Authors(s): {authors} +
+* Date: {revdate} +
 
 Issue: https://github.com/comit-network/comit-rs/issues/897[#477]
 

--- a/0013-secure-http-api.adoc
+++ b/0013-secure-http-api.adoc
@@ -26,14 +26,14 @@ The requirement for encryption is self evident and is the primary focus of this 
 The topic of authentication is not so clear cut.
 Authentication is actually out of scope for this spike but briefly considering here for completeness.
 
-Client authentication refers to three things:
+.Client authentication refers to three things:
 * Identity – who claims to be making an API request?
 * Authentication – are they really who they say they are?
 * Authorization – are they allowed to do what they are trying to do?
 
 At the moment only the first two are of interest to us, all users are allowed to do anything.
 
-Considerations:
+.Considerations:
 * API key
 * username/password
 * Basic authentication with TLS
@@ -47,7 +47,7 @@ Recommend to leave authentication out of scope and only consider encryption.
 
 The industry standard for encrypting traffic over a network is Transport Layer Security (TLS).
 
-What TLS gives us and whether we need it:
+.What TLS gives us and whether we need it:
 * Authentication of cnd - needed, allows client to verify it is connecting to the correct cnd.
 * Data confidentiality - needed, protects against attacker learning the secret.
 * Date integrity - needed, protects against modification of the data i.e. changing the redeem address.
@@ -62,7 +62,8 @@ Adding TLS to cnd should be straightforward.
 TLS is supported by Warp (the web server framework we use).
 The only real consideration is the TLS keypair (key and certificate) and selfsigning the certificate.
 We can provide a default keypair so that cnd works out of the box with TLS.
-This can be done in a few ways:
+
+.This can be done in a few ways:
 * Put the keys in the repository - bad, private keys should be private.
 * Write a standalone tool to generate a new key.
 * Add code to cnd to generate a new keypair if one is not found i.e. in the default place or via a config option `--key=/path/to/key`and `--cert=/path/to/cert`.
@@ -73,7 +74,7 @@ Request content for this section to be written by team member who is familiar wi
 
 == Recommendation
 
-Recommendations are as follows:
+.Recommendations are as follows:
 * Implement TLS for cnd using Warp's TLS support.
 ** Enable TLS by default, add option `--no-tls` to disable it.
 ** Look for keypair in well known location, configurable via configuration file and command line options.

--- a/0013-secure-http-api.adoc
+++ b/0013-secure-http-api.adoc
@@ -1,0 +1,85 @@
+= Securing the `cnd` HTTP API
+
+Tobin C. Harding <tobin.harding@coblox.tech>
+:toc:
+:revdate: 2019-08-13
+
+* Authors(s): {authors}
+* Date: {revdate}
+
+Issue: https://github.com/comit-network/comit-rs/issues/897[#477]
+
+== Context
+
+Currently the HTTP API served by cnd has no security features, all data is sent as plain text.
+This opens an opportunity for a man-in-the-middle attacker to get in between cnd and a client consuming the API e.g., `comit-i`.
+While not critical this is still a security concern, if we are trying to write best practice software we should consider securing the HTTP API.
+
+== Research
+
+First, research how this problem is solved in the wild.
+Read a bunch of stack overflow posts and blog posts, see reference section below for blog post wrapping up this knowledge.
+
+Conclude that in order to fully secure the HTTP API we would need to use some form of encryption and some form of client/server verification.
+The requirement for encryption is self evident and is the primary focus of this spike, all communication between cnd and a client should be encrypted.
+
+The topic of authentication is not so clear cut.
+Authentication is actually out of scope for this spike but briefly considering here for completeness.
+
+Client authentication refers to three things:
+* Identity – who claims to be making an API request?
+* Authentication – are they really who they say they are?
+* Authorization – are they allowed to do what they are trying to do?
+
+At the moment only the first two are of interest to us, all users are allowed to do anything.
+
+Considerations:
+* API key
+* username/password
+* Basic authentication with TLS
+* OAuth
+** Oauth1.Oa
+** OAuth2
+
+Recommend to leave authentication out of scope and only consider encryption.
+
+=== Recap on TLS
+
+The industry standard for encrypting traffic over a network is Transport Layer Security (TLS).
+
+What TLS gives us and whether we need it:
+* Authentication of cnd - needed, allows client to verify it is connecting to the correct cnd.
+* Data confidentiality - needed, protects against attacker learning the secret.
+* Date integrity - needed, protects against modification of the data i.e. changing the redeem address.
+* Replay protection - not needed, replay attack vector currently non-existent for cnd.
+* Sequence protection - no obvious need.
+
+== Implementing TLS for cnd and comit-i
+
+=== cnd (i.e TLS in Rust)
+
+Adding TLS to cnd should be straightforward.
+TLS is supported by Warp (the web server framework we use).
+The only real consideration is the TLS keypair (key and certificate) and selfsigning the certificate.
+We can provide a default keypair so that cnd works out of the box with TLS.
+This can be done in a few ways:
+* Put the keys in the repository - bad, private keys should be private.
+* Write a standalone tool to generate a new key.
+* Add code to cnd to generate a new keypair if one is not found i.e. in the default place or via a config option `--key=/path/to/key`and `--cert=/path/to/cert`.
+
+=== comit-i
+
+Request content for this section to be written by team member who is familiar with `comit-i` and/or React.
+
+== Recommendation
+
+Recommendations are as follows:
+* Implement TLS for cnd using Warp's TLS support.
+** Enable TLS by default, add option `--no-tls` to disable it.
+** Look for keypair in well known location, configurable via configuration file and command line options.
+
+== Reference
+
+* https://stormpath.com/blog/secure-your-rest-api-right-way
+* Warp docs: https://docs.rs/warp/0.1.18/warp/
+* Warp TLS example: https://github.com/seanmonstar/warp/blob/master/examples/tls.rs

--- a/0013-secure-http-api.adoc
+++ b/0013-secure-http-api.adoc
@@ -53,6 +53,10 @@ The industry standard for encrypting traffic over a network is Transport Layer S
 * Replay protection - not needed, replay attack vector currently non-existent for cnd.
 * Sequence protection - no obvious need.
 
+There is a usability concern that for clients that use a webbrowser e.g. `comit-i` how we sign the certificate will effect the user experience.
+A self signed cert will cause a security warning to be displayed by modern browsers.
+Installing a CA to counter the issue will require root privileges, something that we do not wish to require.
+
 == Implementing TLS
 
 === cnd

--- a/0013-secure-http-api.adoc
+++ b/0013-secure-http-api.adoc
@@ -54,7 +54,7 @@ The industry standard for encrypting traffic over a network is Transport Layer S
 
 === Certificates
 
-TLS requires a certificate (private/public keypair) to be preset on the server i.e., cnd.
+TLS requires a certificate (private/public keypair) to be present on both the server and the client i.e., cnd and comit-i respectively.
 Note, this negatively impacts our quarterly OKR #48 (Make COMIT easily accessible).
 
 There are multiple solutions to getting a certificate onto the machine running cnd, each with different pros/cons.
@@ -99,10 +99,12 @@ Create a self signed certificate.
 .cons
 * Adds complexity to the set up of cnd
 * Negatively impacts usability, browser security pop up because of untrusted certificate
+* Browsers such as Firefox will block requests that try to https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSDidNotSucceed?utm_source=devtools&utm_medium=firefox-cors-errors&utm_campaign=default[access an https resource that has an invalid certificate]
 
-According to let's encrypt project this can be partially mitigated if we serve `comit-i` on an IP address instead of on `localhost`
+According to let's encrypt project, the problem with the security pop up can be partially mitigated if we serve `comit-i` on an IP address instead of on `localhost`
 Reference: https://letsencrypt.org/docs/certificates-for-localhost/
 
+All in all, self-signed certificates seem to be a no-go for clients on the browser.
 
 == Implementing TLS
 
@@ -123,10 +125,14 @@ TLS is supported by Warp (the web server framework we use).
 Requires adding a field in the config file and command line options e.g., `--tls-key=/path/to/key` and `--tls-cert=/path/to/cert`.
 Adds an extra initial setup step for the user of cnd to ensure valid certificate is available on the host machine.
 
-=== comit-i
+=== comit-i and other clients
 
-`comit-i` must consume the HTTP API exposed by cnd using TLS
-I was unable to find any information on the internet on how to do this.
+Any client must consume the HTTP API exposed by cnd using TLS.
+For an embedded client such as `comit-i` this means serving it via TLS.
+As stated above, this is supported by the web server framework we use, by providing a key and a certificate.
+
+For alternative client implementations that live outside of `cnd`, the same requirement holds.
+We would have to document this requirement and point to relevant resources.
 
 == Recommendation
 
@@ -138,12 +144,15 @@ The cnd stuff is straightforward.
 ** Look for keypair in well known location, configurable via configuration file and command line options.
 * Leave generation of valid certificate up to the user of cnd but add documentation/hints on how to do this and what options are available (based on information in this spike).
 
-As for `comit-i` my findings were less positive.
-Recommend splitting `comit-i` up into separate parts for the front end and back end and re-writing the back end in Rust.
-Rust has a library `rust-native-tls` which is an abstraction over platform-specific TLS implementations and will facilitate connecting to cnd using TLS.
+In the case of `comit-i`, being a browser-based client imposes fundamental restrictions.
+In particular, the certificates involved in the secure communication cannot be self-signed.
+Satisfying this requirement is feasible, but it's worth re-evaluating our motivation for securing the network communication before implementing anything given the negative implications of using certificates signed by CAs.
 
-.Failed research question:
-* Connect to cnd from `comit-i` using TLS via Typescript or Javascript library.
+== Conclusions
+
+The truth is that the motivation for tackling this spike now was to be able to integrate the popular hardware wallet Nano Ledger S in `comit-i`.
+With that in mind, it's hard to justify undertaking these changes now that we have come to the conclusion that native Nano Ledger S integration is not a priority.
+Furthermore, this investigation has highlighted the fact that we need to carefully consider all possible attack vectors on the HTTP API before we decide on how to secure it.
 
 == Reference
 

--- a/0013-secure-http-api.adoc
+++ b/0013-secure-http-api.adoc
@@ -1,11 +1,10 @@
 = Securing the `cnd` HTTP API
-Tobin C. Harding <tobin.harding@coblox.tech>
+Tobin C. Harding <tobin.harding@coblox.tech>;
 :toc:
 :revdate: 2019-08-13
 
-* Authors(s): {authors} +
-* Date: {revdate} +
-
+NOTE: Author: {authors} +
+Date: {revdate} +
 Issue: https://github.com/comit-network/comit-rs/issues/897[#477]
 
 == Context

--- a/0013-secure-http-api.adoc
+++ b/0013-secure-http-api.adoc
@@ -53,9 +53,9 @@ The industry standard for encrypting traffic over a network is Transport Layer S
 * Replay protection - not needed, replay attack vector currently non-existent for cnd.
 * Sequence protection - no obvious need.
 
-== Implementing TLS for cnd and comit-i
+== Implementing TLS
 
-=== cnd (i.e TLS in Rust)
+=== cnd
 
 Adding TLS to cnd should be straightforward.
 TLS is supported by Warp (the web server framework we use).

--- a/0013-secure-http-api.adoc
+++ b/0013-secure-http-api.adoc
@@ -75,7 +75,7 @@ Purchase a certificate signed by a trusted CA.
 
 ==== Signed certificate by private CA
 
-Use case: running cnd on same machine as the client.
+Use case: connecting to `comit-i` with the machine running cnd.
 Create a private CA and configure the host machine to trust certificates signed by the private CA.
 
 .pros
@@ -89,7 +89,7 @@ Create a private CA and configure the host machine to trust certificates signed 
 
 === Self signed certificate
 
-Use case: running cnd on same machine as the client.
+Use case: connecting to `comit-i` with the machine running cnd.
 Create a self signed certificate.
 
 .pros
@@ -99,6 +99,10 @@ Create a self signed certificate.
 .cons
 * Adds complexity to the set up of cnd
 * Negatively impacts usability, browser security pop up because of untrusted certificate
+
+According to let's encrypt project this can be partially mitigated if we serve `comit-i` on an IP address instead of on `localhost`
+Reference: https://letsencrypt.org/docs/certificates-for-localhost/
+
 
 == Implementing TLS
 

--- a/README.md
+++ b/README.md
@@ -15,5 +15,6 @@ List of spike outcomes for COMIT network.
 - [spike-0010](0010-timestamps.adoc) - Event timestamps
 - [spike-0011](0011-revise-e2e-test-framework.adoc) - Revise e2e test framework
 - [spike-0012](0012-release-strategy.adoc) - Release Strategy
+- [spike-0013](0013-secure-http-api.adoc) - Securing the cnd HTTP API
 
 For new spike outcomes, please use [template.adoc](template.adoc) as basis.


### PR DESCRIPTION
As defined in the issue [below], we would like to consider securing the HTTP API exposed by cnd.  'securing' is an ambiguous term, this spike is limited in scope to encrypting the traffic between cnd and comit-i.

Fixes: https://github.com/comit-network/comit-rs/issues/477